### PR TITLE
Use `Chdir` instead of passing the `-p' flag when the path of the app is a directory

### DIFF
--- a/out/assets/cf
+++ b/out/assets/cf
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo $(basename $0) $*
+echo $PWD $(basename $0) $*
 echo
 env

--- a/out/integration_test.go
+++ b/out/integration_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Out", func() {
 		err = ioutil.WriteFile(filepath.Join(tmpDir, "project", "manifest.yml"), []byte{}, 0555)
 		Ω(err).ShouldNot(HaveOccurred())
 
-		err = ioutil.WriteFile(filepath.Join(tmpDir, "another-project"), []byte{}, 0555)
+		err = os.Mkdir(filepath.Join(tmpDir, "another-project"), 0555)
 		Ω(err).ShouldNot(HaveOccurred())
 
 		request = out.Request{
@@ -90,7 +90,7 @@ var _ = Describe("Out", func() {
 		Ω(err).ShouldNot(HaveOccurred())
 	})
 
-	Context("when my manifest and file paths do not contain a glob", func() {
+	Context("when my manifest and paths do not contain a glob", func() {
 		It("pushes an application to cloud foundry", func() {
 			session, err := gexec.Start(
 				cmd,
@@ -111,9 +111,9 @@ var _ = Describe("Out", func() {
 			Ω(session.Err).Should(gbytes.Say("cf api https://api.run.pivotal.io --skip-ssl-validation"))
 			Ω(session.Err).Should(gbytes.Say("cf auth awesome@example.com hunter2"))
 			Ω(session.Err).Should(gbytes.Say("cf target -o org -s space"))
-			Ω(session.Err).Should(gbytes.Say("cf zero-downtime-push awesome-app -f %s -p %s",
-				filepath.Join(tmpDir, "project/manifest.yml"),
+			Ω(session.Err).Should(gbytes.Say("%s cf zero-downtime-push awesome-app -f %s",
 				filepath.Join(tmpDir, "another-project"),
+				filepath.Join(tmpDir, "project/manifest.yml"),
 			))
 
 			// color should be always


### PR DESCRIPTION
This change will fix an issue when deploying multiple applications using
one manifest file. Currently the `cf' cli will complain with the
followign error message:

Command line flags (except -f) cannot be applied when pushing multiple
apps from a manifest file

This commit modifies the logic to chdir to the app path if it is a
directory, otherwise it reverts to the old behavior and passes `-p' flag
to the cli.