### PR TITLE
add antifreeze manifest checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM concourse/buildroot:base
 
 ADD cf /usr/bin/cf
+
 ADD autopilot /usr/bin/autopilot
 RUN /usr/bin/cf install-plugin -f /usr/bin/autopilot
+
+ADD antifreeze /usr/bin/antifreeze
+RUN /usr/bin/cf install-plugin -f /usr/bin/antifreeze
 
 ADD built-check /opt/resource/check
 ADD built-out /opt/resource/out

--- a/build.yml
+++ b/build.yml
@@ -11,6 +11,7 @@ inputs:
 - name: autopilot
   path: gopath/src/github.com/contraband/autopilot
 - name: cf-cli
+- name: antifreeze
 
 outputs:
 - name: built-resource

--- a/out/cloud_foundry.go
+++ b/out/cloud_foundry.go
@@ -39,7 +39,7 @@ func (cf *CloudFoundry) PushApp(manifest string, path string, currentAppName str
 	zeroDowntimeDeploy := currentAppName != ""
 
 	if zeroDowntimeDeploy {
-		err := cf.cf("check-manifest", currentAppName, "-f ", manifest).Run()
+		err := cf.cf("check-manifest", currentAppName, "-f", manifest).Run()
 		if err != nil {
 			return err
 		}

--- a/out/cloud_foundry.go
+++ b/out/cloud_foundry.go
@@ -36,12 +36,21 @@ func (cf *CloudFoundry) Target(organization string, space string) error {
 }
 
 func (cf *CloudFoundry) PushApp(manifest string, path string, currentAppName string) error {
+	zeroDowntimeDeploy := currentAppName != ""
+
+	if zeroDowntimeDeploy {
+		err := cf.cf("check-manifest", currentAppName, "-f ", manifest).Run()
+		if err != nil {
+			return err
+		}
+	}
+
 	args := []string{}
 
-	if currentAppName == "" {
-		args = append(args, "push", "-f", manifest)
-	} else {
+	if zeroDowntimeDeploy {
 		args = append(args, "zero-downtime-push", currentAppName, "-f", manifest)
+	} else {
+		args = append(args, "push", "-f", manifest)
 	}
 
 	if path != "" {

--- a/out/integration_test.go
+++ b/out/integration_test.go
@@ -107,13 +107,14 @@ var _ = Describe("Out", func() {
 
 			Ω(response.Version.Timestamp).Should(BeTemporally("~", time.Now(), time.Second))
 
+			manifestPath := filepath.Join(tmpDir, "project/manifest.yml")
+
 			// shim outputs arguments
 			Ω(session.Err).Should(gbytes.Say("cf api https://api.run.pivotal.io --skip-ssl-validation"))
 			Ω(session.Err).Should(gbytes.Say("cf auth awesome@example.com hunter2"))
 			Ω(session.Err).Should(gbytes.Say("cf target -o org -s space"))
-			Ω(session.Err).Should(gbytes.Say("cf zero-downtime-push awesome-app -f %s",
-				filepath.Join(tmpDir, "project/manifest.yml"),
-			))
+			Ω(session.Err).Should(gbytes.Say("cf check-manifest awesome-app -f %s", manifestPath))
+			Ω(session.Err).Should(gbytes.Say("cf zero-downtime-push awesome-app -f %s", manifestPath))
 			Ω(session.Err).Should(gbytes.Say(filepath.Join(tmpDir, "another-project")))
 
 			// color should be always
@@ -158,6 +159,7 @@ var _ = Describe("Out", func() {
 				Ω(session.Err).Should(gbytes.Say("cf api https://api.run.pivotal.io --skip-ssl-validation"))
 				Ω(session.Err).Should(gbytes.Say("cf auth awesome@example.com hunter2"))
 				Ω(session.Err).Should(gbytes.Say("cf target -o org -s space"))
+				Ω(session.Err).Should(gbytes.Say("cf check-manifest awesome-app -f %s", tmpFileManifest.Name()))
 				Ω(session.Err).Should(gbytes.Say("cf zero-downtime-push awesome-app -f %s -p %s",
 					tmpFileManifest.Name(),
 					tmpFileSearch.Name(),

--- a/scripts/ci
+++ b/scripts/ci
@@ -57,6 +57,12 @@ BUILD_DIR=$PWD/built-resource
 (
     set -e
 
+    mv antifreeze/antifreeze-linux $BUILD_DIR/antifreeze
+)
+
+(
+    set -e
+
     cd $GOPATH/src/github.com/concourse/cf-resource
 
     cp Dockerfile $BUILD_DIR


### PR DESCRIPTION
This uses the [`antifreeze` plugin](https://github.com/odlp/antifreeze) to check that there are no unexpected services or environment variables that will be destroyed by the deploy.

This requires minor changes to the main pipeline in order to add a GitHub release resource for `antifreeze`. I didn't want to do that though until this got a :+1:.
