### PR TITLE
add option to overwrite/set organization and space with params

### DIFF
--- a/out/command.go
+++ b/out/command.go
@@ -27,9 +27,19 @@ func (command *Command) Run(request Request) (Response, error) {
 		return Response{}, err
 	}
 
+	organization := request.Source.Organization
+	space := request.Source.Space
+	if request.Params.Organization != "" {
+		organization = request.Params.Organization
+	}
+
+	if request.Params.Space != "" {
+		space = request.Params.Space
+	}
+
 	err = command.paas.Target(
-		request.Source.Organization,
-		request.Source.Space,
+		organization,
+		space,
 	)
 	if err != nil {
 		return Response{}, err
@@ -55,11 +65,11 @@ func (command *Command) Run(request Request) (Response, error) {
 		Metadata: []resource.MetadataPair{
 			{
 				Name:  "organization",
-				Value: request.Source.Organization,
+				Value: organization,
 			},
 			{
 				Name:  "space",
-				Value: request.Source.Space,
+				Value: space,
 			},
 		},
 	}, nil
@@ -80,7 +90,7 @@ func (command *Command) setEnvironmentVariables(request Request) error {
 	}
 
 	err = manifest.Save(request.Params.ManifestPath)
-	if (err != nil) {
+	if err != nil {
 		return err
 	}
 

--- a/out/models.go
+++ b/out/models.go
@@ -12,6 +12,8 @@ type Params struct {
 	Path                 string            `json:"path"`
 	CurrentAppName       string            `json:"current_app_name"`
 	EnvironmentVariables map[string]string `json:"environment_variables"`
+	Space                string            `json:"space,omitempty"`
+	Organization         string            `json:"organization,omitempty"`
 }
 
 type Response struct {


### PR DESCRIPTION
This pull request is to add support for setting organization and space with params as well as or instead of source.

If organzation and space are set on both source and params, params will override. It can also be set by just source or just params. Leaving the source option for backwards compatibility and the option to set a "default" org and space.

This pull request should satisfy #18