### PR TITLE
Increase CF_Dial_timeout to 30

### DIFF
--- a/out/cloud_foundry.go
+++ b/out/cloud_foundry.go
@@ -79,6 +79,6 @@ func (cf *CloudFoundry) cf(args ...string) *exec.Cmd {
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	cmd.Env = append(os.Environ(), "CF_COLOR=true")
-
+	cmd.Env = append(os.Environ(), "CF_DIAL_TIMEOUT=30")
 	return cmd
 }


### PR DESCRIPTION
The default 5 second timeout http://cli.cloudfoundry.org/en-US/cf/ causes the CF resource to timeout to pivotal web service from a concourse worker on AWS in us-east-1. This PR will bump up the default a bit.