### PR TITLE
Move top-level environment variables into apps.

### DIFF
--- a/out/assets/manifest.yml
+++ b/out/assets/manifest.yml
@@ -1,5 +1,6 @@
 applications:
-- name: app
+- name: app1
   env:
     MANIFEST_A: manifest_a
     MANIFEST_B: manifest_b
+- name: app2

--- a/out/assets/manifest.yml
+++ b/out/assets/manifest.yml
@@ -1,3 +1,5 @@
-env:
-  MANIFEST_A: manifest_a
-  MANIFEST_B: manifest_b
+applications:
+- name: app
+  env:
+    MANIFEST_A: manifest_a
+    MANIFEST_B: manifest_b

--- a/out/command_test.go
+++ b/out/command_test.go
@@ -182,6 +182,8 @@ var _ = Describe("Out Command", func() {
 
 				Expect(manifest.EnvironmentVariables()[0]["COMMAND_TEST_A"]).To(Equal("command_test_a"))
 				Expect(manifest.EnvironmentVariables()[0]["COMMAND_TEST_B"]).To(Equal("command_test_b"))
+				Expect(manifest.EnvironmentVariables()[1]["COMMAND_TEST_A"]).To(Equal("command_test_a"))
+				Expect(manifest.EnvironmentVariables()[1]["COMMAND_TEST_B"]).To(Equal("command_test_b"))
 			})
 		})
 
@@ -189,10 +191,11 @@ var _ = Describe("Out Command", func() {
 			It("doesn't set the environment variables", func() {
 				manifest, err := out.NewManifest(request.Params.ManifestPath)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(manifest.EnvironmentVariables()).To(HaveLen(1))
+				Expect(manifest.EnvironmentVariables()).To(HaveLen(2))
 				Expect(manifest.EnvironmentVariables()[0]).To(HaveLen(2))
 				Expect(manifest.EnvironmentVariables()[0]).To(HaveKeyWithValue("MANIFEST_A", "manifest_a"))
 				Expect(manifest.EnvironmentVariables()[0]).To(HaveKeyWithValue("MANIFEST_B", "manifest_b"))
+				Expect(manifest.EnvironmentVariables()[1]).To(HaveLen(0))
 			})
 		})
 

--- a/out/command_test.go
+++ b/out/command_test.go
@@ -180,8 +180,8 @@ var _ = Describe("Out Command", func() {
 			It("writes the variables into the manifest", func() {
 				manifest, _ := out.NewManifest(request.Params.ManifestPath)
 
-				Expect(manifest.EnvironmentVariables()["COMMAND_TEST_A"]).To(Equal("command_test_a"))
-				Expect(manifest.EnvironmentVariables()["COMMAND_TEST_B"]).To(Equal("command_test_b"))
+				Expect(manifest.EnvironmentVariables()[0]["COMMAND_TEST_A"]).To(Equal("command_test_a"))
+				Expect(manifest.EnvironmentVariables()[0]["COMMAND_TEST_B"]).To(Equal("command_test_b"))
 			})
 		})
 
@@ -189,9 +189,10 @@ var _ = Describe("Out Command", func() {
 			It("doesn't set the environment variables", func() {
 				manifest, err := out.NewManifest(request.Params.ManifestPath)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(manifest.EnvironmentVariables()).To(HaveLen(2))
-				Expect(manifest.EnvironmentVariables()).To(HaveKeyWithValue("MANIFEST_A", "manifest_a"))
-				Expect(manifest.EnvironmentVariables()).To(HaveKeyWithValue("MANIFEST_B", "manifest_b"))
+				Expect(manifest.EnvironmentVariables()).To(HaveLen(1))
+				Expect(manifest.EnvironmentVariables()[0]).To(HaveLen(2))
+				Expect(manifest.EnvironmentVariables()[0]).To(HaveKeyWithValue("MANIFEST_A", "manifest_a"))
+				Expect(manifest.EnvironmentVariables()[0]).To(HaveKeyWithValue("MANIFEST_B", "manifest_b"))
 			})
 		})
 

--- a/out/manifest_test.go
+++ b/out/manifest_test.go
@@ -23,9 +23,9 @@ var _ = Describe("Manifest", func() {
 		})
 
 		It("can extract the environment variables", func() {
-			envVars := manifest.EnvironmentVariables()
-			Expect(envVars["MANIFEST_A"]).To(Equal("manifest_a"))
-			Expect(envVars["MANIFEST_B"]).To(Equal("manifest_b"))
+			appEnvVars := manifest.EnvironmentVariables()
+			Expect(appEnvVars[0]["MANIFEST_A"]).To(Equal("manifest_a"))
+			Expect(appEnvVars[0]["MANIFEST_B"]).To(Equal("manifest_b"))
 		})
 
 		Context("when updated", func() {
@@ -45,9 +45,9 @@ var _ = Describe("Manifest", func() {
 
 				updatedManifest, err := out.NewManifest(tempFile.Name())
 				Expect(err).NotTo(HaveOccurred())
-				Expect(updatedManifest.EnvironmentVariables()["MANIFEST_A"]).To(Equal("manifest_a"))
-				Expect(updatedManifest.EnvironmentVariables()["MANIFEST_B"]).To(Equal("manifest_b"))
-				Expect(updatedManifest.EnvironmentVariables()["MANIFEST_TEST_A"]).To(Equal("manifest_test_a"))
+				Expect(updatedManifest.EnvironmentVariables()[0]["MANIFEST_A"]).To(Equal("manifest_a"))
+				Expect(updatedManifest.EnvironmentVariables()[0]["MANIFEST_B"]).To(Equal("manifest_b"))
+				Expect(updatedManifest.EnvironmentVariables()[0]["MANIFEST_TEST_A"]).To(Equal("manifest_test_a"))
 			})
 		})
 	})

--- a/out/manifest_test.go
+++ b/out/manifest_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Manifest", func() {
 				Expect(updatedManifest.EnvironmentVariables()[0]["MANIFEST_A"]).To(Equal("manifest_a"))
 				Expect(updatedManifest.EnvironmentVariables()[0]["MANIFEST_B"]).To(Equal("manifest_b"))
 				Expect(updatedManifest.EnvironmentVariables()[0]["MANIFEST_TEST_A"]).To(Equal("manifest_test_a"))
+				Expect(updatedManifest.EnvironmentVariables()[1]["MANIFEST_TEST_A"]).To(Equal("manifest_test_a"))
 			})
 		})
 	})


### PR DESCRIPTION
Configuration outside the `applications` block, or "promoted content", is now deprecated: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#-yaml-anchors-replace-promoted-content. This patch applies variables in `environment_variables` to each application within `applications` rather than as promoted content.

Fixes #54.