### PR TITLE
Add "-p ." for directory path arguments.

### DIFF
--- a/out/cloud_foundry.go
+++ b/out/cloud_foundry.go
@@ -83,6 +83,7 @@ func (cf *CloudFoundry) PushApp(
 			return err
 		}
 		if stat.IsDir() {
+			args = append(args, "-p", ".")
 			return chdir(path, cf.cf(args...).Run)
 		}
 


### PR DESCRIPTION
Currently, when the `path` param points to a directory, the `-p` command line flag is omitted (only `$PWD` is changed). This prevents deployment if the `path` param is used to override a value from the `manifest.yml`.
This patch adds the flag `-p .` (in addition to the `chdir()` call), so that the path from the `manifest.yml` is overridden in all cases.